### PR TITLE
[PacMin-1] Adding MinHash based Jaccard similarity estimator.

### DIFF
--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/HashStore.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/HashStore.scala
@@ -1,0 +1,53 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.minhash
+
+import scala.util.Random
+
+private[minhash] object HashStore {
+
+  /**
+   * Generates a hash store that is a given length with a given seed.
+   *
+   * @param length The desired length of the hash store.
+   * @param seed A seed for the random number generator.
+   * @return Returns a randomized store of the requested length.
+   */
+  def apply(length: Int, seed: Long): HashStore = {
+    val rgen = new Random(seed)
+
+    // generate random values
+    new HashStore((0 until length).map(i => rgen.nextInt()).toArray)
+  }
+}
+
+private[minhash] class HashStore private (hashes: Array[Int]) extends Serializable {
+
+  /**
+   * Gets a hash from an index location.
+   *
+   * @param idx Index of the hash to get.
+   * @return Int Returns the integer hash value.
+   */
+  def apply(idx: Int): Int = hashes(idx)
+
+  /**
+   * @return Returns the number of hashes in the store.
+   */
+  def size: Int = hashes.length
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHash.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHash.scala
@@ -1,0 +1,179 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.minhash
+
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+
+/**
+ * This object presents several methods for determining approximate pair-wise
+ * Jaccard similarity through the use of MinHash signatures. A description of
+ * this algorithm can be found in chapter 3 of:
+ *
+ * Rajaraman, Anand, and Jeffrey David Ullman. Mining of massive datasets.
+ * Cambridge University Press, 2011.
+ *
+ * This chapter may be freely (and legally) downloaded from:
+ * 
+ * http://infolab.stanford.edu/~ullman/mmds/ch3.pdf
+ */
+object MinHash extends Serializable {
+
+  /**
+   * Implements an exact pair-wise MinHash similarity check. Exact refers to
+   * "all-pairs", not "similarity"; MinHash signature comparison approximates
+   * Jaccard similarity, and this method _exactly_ compares all pairs of inputs,
+   * as opposed to locality sensitive hashing (LSH) based approximations.
+   *
+   * @note This operation may be expensive, as it performs a cartesian
+   *       product of all elements in the input RDD.
+   *
+   * @tparam T This function will operate on RDDs containing any type T that
+   *         extends the MinHashable trait.
+   * 
+   * @param rdd The RDD of data points to compute similarity on.
+   * @param signatureLength The length of MinHash signature to use.
+   * @param randomSeed An optional seed for random number generation.
+   * @returns Returns an RDD containing all pairs of elements, with their
+   *          similarity, as a tuple of (similarity, (elem1, elem2)).
+   */
+  def exactMinHash[T <: MinHashable](rdd: RDD[T],
+                                     signatureLength: Int,
+                                     randomSeed: Option[Long] = None): RDD[(Double, (T, T))] = {
+    // generate signatures
+    val signedRdd = generateSignatures(rdd, signatureLength, randomSeed)
+
+    // cartesian this rdd by itself
+    val allPairsRdd = signedRdd.cartesian(signedRdd)
+
+    // compute estimated jaccard similarity and return
+    allPairsRdd.map(p => {
+      val ((sig1, item1), (sig2, item2)) = p
+
+      (sig1.similarity(sig2), (item1, item2))
+    })
+  }
+
+  /**
+   * Implements an approximate pair-wise MinHash similarity check. Approximate
+   * refers to "all-pairs", not "similarity"; MinHash signature comparison
+   * approximates Jaccard similarity. This method uses a locality sensitive
+   * hashing (LSH) based approach to reduce the number of comparisons required.
+   *
+   * We use the LSH technique described in section 3.4.1 of the Ullman text.
+   * This technique creates _b_ bands which divide the hashing space. For a
+   * MinHash signature with length _l_, we require b * r = l, where _r_ is
+   * the number of rows in each band. For given _b_ and _r_, we expect to
+   * compare all elements with similarity greater than (1/b)^(1/r).
+   *
+   * @throws IllegalArgumentException Throws an illegal argument exception if
+   *                                  the number of bands does not divide
+   *                                  evenly into the signature length.
+   *
+   * @tparam T This function will operate on RDDs containing any type T that
+   *         extends the MinHashable trait.
+   *
+   * @param rdd The RDD of data points to compute similarity on.
+   * @param signatureLength The length of MinHash signature to use.
+   * @param bands The number of bands to use for LSHing.
+   * @param randomSeed An optional seed for random number generation.
+   * @returns Returns an RDD containing all pairs of elements, with their
+   *          similarity, as a tuple of (similarity, (elem1, elem2)).
+   */
+  def approximateMinHash[T <: MinHashable](rdd: RDD[T],
+                                           signatureLength: Int,
+                                           bands: Int,
+                                           randomSeed: Option[Long] = None): RDD[(Double, (T, T))] = {
+    // generate signatures
+    val signedRdd = generateSignatures(rdd, signatureLength, randomSeed)
+
+    // get band length
+    if (signatureLength % bands != 0) {
+      throw new IllegalArgumentException("Signature length must divide roundly by the band count.")
+    }
+    val bandLength = signatureLength / bands
+
+    // replicate all keys into buckets and group by key
+    val bucketGroups = signedRdd.flatMap(kv => {
+      val (signature, item) = kv
+
+      // split signature into buckets
+      val buckets = signature.bucket(bandLength)
+
+      // copy key per bucket
+      buckets.map(bucket => (bucket, (signature, item)))
+    }).groupByKey()
+
+    // per bucket, take inner product and compute similarity
+    bucketGroups.flatMap(kv => {
+      val (bucket, pairs) = kv
+
+      // convert pairs to an array
+      val pairArray = pairs.toArray
+
+      // create list to append to
+      var l = List[(Double, (T, T))]()
+
+      // loop over contents to take inner product
+      (0 until pairArray.length).foreach(i => {
+        ((i + 1) until pairArray.length).foreach(j => {
+          val (sig1, item1) = pairArray(i)
+          val (sig2, item2) = pairArray(j)
+
+          // is this the first bucket these elements overlap in? if not, don't
+          // process to limit the number of dupes emitted
+          if (MinHashSignature.firstBucket(sig1, sig2, bandLength).get.equals(bucket)) {
+            // compute similarity and add to list
+            l = (sig1.similarity(sig2), (item1, item2)) :: l
+          }
+        })
+      })
+
+      // return list
+      l
+    })
+  }
+
+  /**
+   * @param randomSeed An optional random seed.
+   * @return Unpacks the random seed if one is provided, else returns the
+   *         current Linux timestamp.
+   */
+  private def getSeed(randomSeed: Option[Long]): Long = randomSeed match {
+    case Some(i) => i
+    case _       => System.currentTimeMillis()
+  }
+
+  /**
+   * Generates the signatures for an RDD of input elements.
+   *
+   * @param rdd The RDD to generate signatures for.
+   * @param signatureLength The desired signature length.
+   * @param randomSeed An optional seed for randomization.
+   * @return Returns an RDD of signature/item pairs.
+   */
+  private def generateSignatures[T <: MinHashable](rdd: RDD[T],
+                                                   signatureLength: Int,
+                                                   randomSeed: Option[Long]): RDD[(MinHashSignature, T)] = {
+    // generate random hash store
+    val hashStore = HashStore(signatureLength, getSeed(randomSeed))
+
+    // key each item by its signature
+    rdd.keyBy(_.minHash(hashStore))
+  }
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHashBucketKey.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHashBucketKey.scala
@@ -1,0 +1,37 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.minhash
+
+private[minhash] case class MinHashBucketKey(band: Int, keys: Array[Int]) {
+
+  /**
+   * @param other Value to similarity against.
+   * @returns True if the value is also a MinHashBucketKey and the band and all
+   *          keys match.
+   */
+  override def equals(other: Any): Boolean = other match {
+    case mhbk: MinHashBucketKey => {
+      mhbk.band == band && mhbk.keys.sameElements(keys)
+    }
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    17 * band + keys.reduceLeft((v1, v2) => 31 * v1 + v2)
+  }
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHashSignature.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHashSignature.scala
@@ -1,0 +1,100 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.minhash
+
+private[minhash] object MinHashSignature {
+
+  /**
+   * For two signatures, finds the key for the first bucket that both signatures
+   * hash to, if one exists.
+   *
+   * @note This method does not check to ensure that the band size divides
+   *       roundly into the size of the signature; we delegate this check
+   *       to the function caller.
+   *
+   * @param sig1 First signature to compare.
+   * @param sig2 Second signature to compare.
+   * @param bandSize The size of bands to use.
+   * @return Returns an option containing the first overlapping bucket key, if
+   *         one exists.
+   */
+  def firstBucket(sig1: MinHashSignature,
+                  sig2: MinHashSignature,
+                  bandSize: Int): Option[MinHashBucketKey] = {
+    // get and zip buckets
+    val keys = sig1.bucket(bandSize).zip(sig2.bucket(bandSize))
+
+    // find first bucket where the two are equal, and take the band
+    keys.find(p => p._1.equals(p._2))
+      .map(p => p._1)
+  }
+}
+
+private[minhash] case class MinHashSignature(hashArray: Array[Int]) {
+
+  /**
+   * Splits this signature into multiple bands, which can then be used to
+   * drive locality sensitive approximate checking.
+   *
+   * @note This method does not check to ensure that the band size divides
+   *       roundly into the size of the signature; we delegate this check
+   *       to the function caller.
+   *
+   * @param The number of signature rows to use per band.
+   * @return Returns this signature sliced into multiple band keys.
+   */
+  def bucket(bandSize: Int): Iterable[MinHashBucketKey] = {
+    // split into groups
+    val groups = hashArray.grouped(bandSize)
+
+    // build and return keys
+    var band = -1
+
+    groups.map(keys => {
+      band += 1
+      MinHashBucketKey(band, keys)
+    }).toIterable
+  }
+
+  /**
+   * Computes the estimated Jaccard similarity of two objects that have MinHash
+   * signatures.
+   *
+   * @note This signature must be the same length as the signature we are
+   *       comparing to. We do not perform this check; we delegate this check
+   *       to the function caller.
+   *
+   * @param Another signature to similarity against.
+   * @return Returns the estimated Jaccard similarity of two signatures, which
+   *         is defined as the number of elements in the signature that agree
+   *         over the total length of the signature.
+   */
+  def similarity(other: MinHashSignature): Double = {
+    var overlap = 0
+
+    // loop over elements - increment overlap count if signatures match
+    (0 until hashArray.length).foreach(i => {
+      if (hashArray(i) == other.hashArray(i)) {
+        overlap += 1
+      }
+    })
+
+    // similarity is the number of matching elements over the signature length
+    overlap.toDouble / hashArray.length.toDouble
+  }
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHashable.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHashable.scala
@@ -1,0 +1,70 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.minhash
+
+import scala.math.min
+
+trait MinHashable {
+
+  /**
+   * Provides the hashes for all of the shingles in an object we are minhashing.
+   *
+   * @return Returns an array containing a hash per shingle.
+   */
+  def provideHashes(): Array[Int]
+
+  /**
+   * Updates the minhash signature of an object with the hash of a shingle from
+   * the object. This method is kept private as it is only for internal use.
+   *
+   * @param hash The hash of the shingle we are processing.
+   * @param hashStore A table containing random values.
+   * @param hashArray The signature we are updating.
+   */
+  private def applyHash(hash: Int,
+                        hashStore: HashStore,
+                        hashArray: Array[Int]) = {
+    // loop over the hashes and attempt an update
+    (0 until hashStore.size).foreach(i => {
+      hashArray(i) = min(hashArray(i), hashStore(i) ^ hash)
+    })
+  }
+
+  /**
+   * Computes the minhash signature for an object.
+   *
+   * @param hashStore The randomized hash store to use when computing the signature.
+   * @return Returns the signature of this object.
+   */
+  final private[minhash] def minHash(hashStore: HashStore): MinHashSignature = {
+
+    // get hashes
+    val hashes = provideHashes()
+
+    // initialize by creating an array and setting everything to Inf
+    val hashArray = new Array[Int](hashStore.size)
+
+    (0 until hashStore.size).foreach(i => hashArray(i) = Int.MaxValue)
+
+    // loop over hashes and apply minhashing algorithm
+    hashes.foreach(hash => applyHash(hash, hashStore, hashArray))
+
+    // return the hash array
+    MinHashSignature(hashArray)
+  }
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/overlapping/MinHashableRead.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/overlapping/MinHashableRead.scala
@@ -1,0 +1,41 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.overlapping
+
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.pacmin.minhash.MinHashable
+
+case class MinHashableRead(read: AlignmentRecord,
+                           kmerLen: Int) extends MinHashable {
+
+  /**
+   * Create hashes for this read by breaking it into shingles by splitting
+   * it into equal length k-mers, then take the hash code of each k-mer string.
+   *
+   * @return Returns an array containing the hash code of each k-mer in the read.
+   */
+  def provideHashes(): Array[Int] = {
+    read.getSequence
+      .toString
+      .sliding(kmerLen)
+      .map(_.hashCode)
+      .toArray
+  }
+
+  override def toString: String = read.toString
+}

--- a/pacmin-core/src/test/scala/org/bdgenomics/pacmin/minhash/MinHashSignatureSuite.scala
+++ b/pacmin-core/src/test/scala/org/bdgenomics/pacmin/minhash/MinHashSignatureSuite.scala
@@ -1,0 +1,48 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.minhash
+
+import org.scalatest.FunSuite
+import scala.math.abs
+
+class MinHashSignatureSuite extends FunSuite {
+
+  def fpEquals(a: Double, b: Double, tol: Double = 1e-6): Boolean = {
+    abs(a - b) < tol
+  }
+
+  test("compute the similarity of signatures") {
+    assert(fpEquals(MinHashSignature(Array(0, 1, 2, 3))
+      .similarity(MinHashSignature(Array(0, 1, 2, 3))), 1.0))
+    assert(fpEquals(MinHashSignature(Array(0, 1, 2, 3))
+      .similarity(MinHashSignature(Array(0, 1, 2, 5))), 0.75))
+    assert(fpEquals(MinHashSignature(Array(0, 1, 2, 3))
+      .similarity(MinHashSignature(Array(1, 1, 2, 0))), 0.5))
+    assert(fpEquals(MinHashSignature(Array(0, 1, 2, 3))
+      .similarity(MinHashSignature(Array(1, 0, 0, 3))), 0.25))
+    assert(fpEquals(MinHashSignature(Array(0, 1, 2, 3))
+      .similarity(MinHashSignature(Array(3, 2, 1, 0))), 0.0))
+  }
+
+  test("compute buckets for a simple signature") {
+    val buckets = MinHashSignature(Array(0, 1, 2, 3)).bucket(2)
+
+    assert(buckets.head === MinHashBucketKey(0, Array(0, 1)))
+    assert(buckets.last === MinHashBucketKey(1, Array(2, 3)))
+  }
+}

--- a/pacmin-core/src/test/scala/org/bdgenomics/pacmin/minhash/MinHashSuite.scala
+++ b/pacmin-core/src/test/scala/org/bdgenomics/pacmin/minhash/MinHashSuite.scala
@@ -1,0 +1,148 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.minhash
+
+import org.bdgenomics.adam.util.SparkFunSuite
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.pacmin.overlapping.MinHashableRead
+import scala.math.abs
+import scala.util.Random
+
+class MinHashSuite extends SparkFunSuite {
+
+  def randomString(seed: Int, len: Int): String = {
+    val r = new Random(seed)
+
+    (0 until len).map(i => r.nextInt(4))
+      .map(i => i match {
+        case 0 => "A"
+        case 1 => "C"
+        case 2 => "G"
+        case _ => "T"
+      }).reduceLeft(_ + _)
+  }
+
+  val kmerLength = 15
+
+  def expectedSimilarity(difference: Long): Double = {
+    def kmersPerSequence(length: Int): Int = {
+      if (length > 0) {
+        length - kmerLength + 1
+      } else {
+        0
+      }
+    }
+    val similarSequence = 1000 - difference.toInt * 100
+    val distinctSequencePerRead = difference.toInt * 100
+    kmersPerSequence(similarSequence).toDouble / (2.0 * kmersPerSequence(distinctSequencePerRead) +
+      kmersPerSequence(similarSequence))
+  }
+
+  val baseString = randomString(0, 2000)
+
+  def fpCompare(a: Double, b: Double, epsilon: Double = 1e-6): Boolean = {
+    abs(a - b) < epsilon
+  }
+
+  sparkTest("compute exact overlap for ten 1000 bp reads") {
+    var read = -1
+    val reads = sc.parallelize(baseString
+      .sliding(1000, 100)
+      .toSeq
+      .map(s => {
+        read += 1
+        MinHashableRead(AlignmentRecord.newBuilder()
+          .setStart(read)
+          .setSequence(s)
+          .build(), kmerLength)
+      }))
+
+    val exact = MinHash.exactMinHash(reads, 500, Option(1L))
+      .collect()
+
+    assert(exact.length === 121)
+    exact.foreach(kv => {
+      val (similarity, (r1, r2)) = kv
+      val expected = expectedSimilarity(abs(r1.read.getStart - r2.read.getStart))
+
+      assert(fpCompare(similarity, expected, 0.1))
+    })
+  }
+
+  sparkTest("compute approximate overlap for ten 1000 bp reads across different band sizes") {
+    var read = -1
+    val reads = sc.parallelize(baseString
+      .sliding(1000, 100)
+      .toSeq
+      .map(s => {
+        read += 1
+        MinHashableRead(AlignmentRecord.newBuilder()
+          .setStart(read)
+          .setSequence(s)
+          .build(), kmerLength)
+      }))
+
+    // compare against the exact approach - build a map for lookup
+    val exact = MinHash.exactMinHash(reads, 500, Option(1L))
+      .collect()
+      .map(kv => {
+        val (similarity, (r1, r2)) = kv
+
+        ((r1.read.getStart, r2.read.getStart), similarity)
+      }).toMap
+    var lastLength = exact.size
+
+    Seq(100, 50, 25, 20, 10).foreach(bands => {
+      val approx = MinHash.approximateMinHash(reads, 500, bands, Option(1L))
+        .collect()
+
+      val newLength = approx.length
+      assert(newLength <= lastLength)
+      lastLength = newLength
+
+      approx.foreach(kv => {
+        val (similarity, (r1, r2)) = kv
+        val expected = expectedSimilarity(abs(r1.read.getStart - r2.read.getStart))
+
+        assert(fpCompare(similarity, expected, 0.1))
+        assert(fpCompare(similarity, exact((r1.read.getStart, r2.read.getStart))))
+      })
+
+      // check that we don't have any dupe keys
+      assert(approx.map(kv => kv._2).distinct.length === approx.length)
+    })
+  }
+
+  sparkTest("should throw exception if we pick an illegal band count") {
+    var read = -1
+    val reads = sc.parallelize(baseString
+      .sliding(1000, 100)
+      .toSeq
+      .map(s => {
+        read += 1
+        MinHashableRead(AlignmentRecord.newBuilder()
+          .setStart(read)
+          .setSequence(s)
+          .build(), kmerLength)
+      }))
+
+    intercept[IllegalArgumentException] {
+      MinHash.approximateMinHash(reads, 500, 13, Option(1L))
+    }
+  }
+}


### PR DESCRIPTION
Implements feature #1, by providing a generalized framework for computing the similarity between two texts. We compute the similarity between two reads, but it can be used to compute the similarity between any two values that extend the MinHashable trait.
