### PR TITLE
[PacMin-9] Stub out assembler architecture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,14 @@ freenode.net channel. Come join us and ask questions.
 
 PacMin is released under an [Apache 2.0 license](LICENSE.txt).
 
+# Distribution
 
+Snapshots of PacMin are available from the [Sonatype OSS](oss.sonatype.org) repository:
+
+```
+<groupId>org.bdgenomics.pacmin</groupId>
+<artifactId>pacmin-core</artifactId>
+<version>0.0.1-SNAPSHOT</version>
+```
+
+Once we've got a release, we will publish to [Maven Central](search.maven.org).

--- a/pacmin-core/pom.xml
+++ b/pacmin-core/pom.xml
@@ -121,6 +121,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-graphx_${scala.version.prefix}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/graph/Linkage.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/graph/Linkage.scala
@@ -1,0 +1,27 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.graph
+
+/**
+ * An edge in the quasitig graph which indicates the reads which support a
+ * connection between two quasitigs.
+ *
+ * @param readSupport An array containing the IDs of reads spanning the quasitigs.
+ */
+private[graph] case class Linkage(readSupport: Array[Long]) {
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/graph/ObservedSite.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/graph/ObservedSite.scala
@@ -1,0 +1,31 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.graph
+
+/**
+ * An observation inside of a quasitig. This is used for calling the sequence of
+ * the finalized multig, and is generated via the transitive reduction of reads.
+ *
+ * @param alleles The allele strings observed at this site.
+ * @likelihoods The likelihoods that each allele was observed.
+ */
+private[graph] case class ObservedSite(alleles: Array[String],
+                                       likelihoods: Array[Double]) {
+  assert(likelihoods.length == alleles.length,
+    "Likelihood:allele mapping must be 1:1.")
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/graph/OverlapGraph.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/graph/OverlapGraph.scala
@@ -1,0 +1,72 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.graph
+
+import org.apache.spark.graphx.Graph
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.pacmin.models.{ Multig, Overlap }
+
+object OverlapGraph {
+
+  /**
+   * Takes in an input overlap graph and reduces it down into multigs.
+   *
+   * @param overlapGraph Input graph of overlapping reads.
+   * @return Returns a set of multigs (multi-allele contigs).
+   */
+  def apply(overlapGraph: Graph[Overlap, AlignmentRecord]): RDD[Multig] = {
+    // reduce this string graph down into quasitigs
+    val quasitigGraph = transitivelyReduceOverlaps(overlapGraph)
+
+    // finalize our quasitigs into multigs
+    finalizeQuasitigs(quasitigGraph)
+  }
+
+  /**
+   * Takes in an input overlap graph, and converts it into a string graph. String
+   * graphs are described in:
+   *
+   * Myers, Eugene W. "The fragment assembly string graph."
+   * Bioinformatics 21.suppl 2 (2005): ii79-ii85.
+   *
+   * Performs a transitive reduction across the overlap graph, which coalesces
+   * overlapping reads down into quasitigs. Quasitigs are a probabilistic
+   * equivalent to contigs; specifically, the sequence is expressed as a probability,
+   * and the ploidy of the contig is not yet known.
+   *
+   * @param stringGraph Input string graph.
+   * @return Returns a quasitig graph, which provides a set of quasitigs which
+   *         are linked by spanning reads.
+   */
+  private[graph] def transitivelyReduceOverlaps(stringGraph: Graph[Overlap, AlignmentRecord]): Graph[Linkage, Quasitig] = {
+    ???
+  }
+
+  /**
+   * Takes in the quasitig graph and finalizes it into multigs. This function
+   * must assign ploidy to the quasitigs, and then call the sequences of the
+   * quasitigs.
+   *
+   * @param quasitigGraph Input quasitig graph.
+   * @return An RDD containing finalized multigs.
+   */
+  private[graph] def finalizeQuasitigs(quasitigGraph: Graph[Linkage, Quasitig]): RDD[Multig] = {
+    ???
+  }
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/graph/Quasitig.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/graph/Quasitig.scala
@@ -1,0 +1,29 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.graph
+
+/**
+ * A quasitig is a probabilistic description of the sequence of a multig, and
+ * represents the unprocessed sequence of overlapped, non-error corrected reads.
+ *
+ * @param sequence An array describing the sequence we've sensed in this quasitig.
+ * @param predictedPloidy The predicted but not-finalized ploidy of this quasitig.
+ */
+private[graph] case class Quasitig(sequence: Array[ObservedSite],
+                                   predictedPloidy: Double) {
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHash.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/minhash/MinHash.scala
@@ -29,7 +29,7 @@ import org.apache.spark.rdd.RDD
  * Cambridge University Press, 2011.
  *
  * This chapter may be freely (and legally) downloaded from:
- * 
+ *
  * http://infolab.stanford.edu/~ullman/mmds/ch3.pdf
  */
 object MinHash extends Serializable {
@@ -45,7 +45,7 @@ object MinHash extends Serializable {
    *
    * @tparam T This function will operate on RDDs containing any type T that
    *         extends the MinHashable trait.
-   * 
+   *
    * @param rdd The RDD of data points to compute similarity on.
    * @param signatureLength The length of MinHash signature to use.
    * @param randomSeed An optional seed for random number generation.

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/models/Multig.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/models/Multig.scala
@@ -1,0 +1,56 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.models
+
+/**
+ * A multig is a "multi-allelic" contig. Specifically, a multig represents
+ * a contig that occurs more than once (e.g., ploidy > 1, or is repeated), where
+ * there may be slight divergence between the two occurrences (e.g., there is a
+ * SNP contained in the multig).
+ *
+ * @param sample The name of this sample.
+ * @param id The ID of this multig in this sample.
+ * @param rightMultigs The multigs to the right of this multig, if any.
+ * @param leftMultigs The multigs to the left of this multig, if any.
+ * @param sequences The base strings in this multig.
+ * @param qualities The phred scaled qualities for all bases called in this multig.
+ */
+case class Multig(sample: String,
+                  id: Long,
+                  rightMultigs: Array[Long],
+                  leftMultigs: Array[Long],
+                  sequences: Array[String],
+                  qualities: Array[Array[Int]]) {
+
+  val ploidy = sequences.length
+  assert((rightMultigs.length == ploidy || rightMultigs.length == 0) &&
+    (leftMultigs.length == ploidy || leftMultigs.length == 0) &&
+    qualities.length == ploidy,
+    "Ploidy must be consistent across data structure.")
+  (0 until ploidy).foreach(i => {
+    assert(sequences(i).length == qualities(i).length,
+      "Sequence/quality length mismatch for #" + i + ".")
+  })
+
+  /**
+   * @return Returns the description of this multig in FASTG format.
+   */
+  def toFastg(): String = {
+    ???
+  }
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/models/Overlap.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/models/Overlap.scala
@@ -1,0 +1,29 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.models
+
+/**
+ * Description of the overlap between two reads.
+ *
+ * @param estimatedSize The estimated size (in bases) of the overlap.
+ * @param switchesStrands True if we believe that the two reads are from
+ *                        different strands.
+ */
+case class Overlap(estimatedSize: Int,
+                   switchesStrands: Boolean) {
+}

--- a/pacmin-core/src/main/scala/org/bdgenomics/pacmin/overlapping/Overlapper.scala
+++ b/pacmin-core/src/main/scala/org/bdgenomics/pacmin/overlapping/Overlapper.scala
@@ -1,0 +1,45 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.pacmin.overlapping
+
+import org.apache.spark.graphx.Graph
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.pacmin.models.Overlap
+
+object Overlapper extends Serializable {
+
+  /**
+   * Takes in reads, and uses a MinHash-based Jaccard similarity estimator to
+   * find overlaps between reads.
+   *
+   * @param reads Set of reads to overlap.
+   * @param overlapThreshold Minimum threshold for emitting an overlap.
+   * @param signatureLength MinHash signature length to use.
+   * @param kmerLength Length of k-mers to use when shingling reads.
+   * @param bands Optional band parameter. See MinHash implementation for details.
+   * @return Returns a graph which connects overlapping reads together.
+   */
+  def apply(reads: RDD[AlignmentRecord],
+            overlapThreshold: Double,
+            signatureLength: Int,
+            kmerLength: Int,
+            bands: Option[Int]): Graph[Overlap, AlignmentRecord] = {
+    ???
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <scala.version>2.10.3</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
     <avro.version>1.7.6</avro.version>
-    <spark.version>1.0.1</spark.version>
+    <spark.version>1.1.0</spark.version>
     <parquet.version>1.4.3</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
@@ -372,6 +372,11 @@
       <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_${scala.version.prefix}</artifactId>
+        <version>${spark.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-graphx_${scala.version.prefix}</artifactId>
         <version>${spark.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fixes #9 by adding stubs for the end-to-end pipeline.
